### PR TITLE
Avoid copying mutex in Logger.WithPrefix and track writer destination

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,56 +1,60 @@
 package logger
 
 import (
-    "fmt"
-    "log"
-    "os"
-    "sync"
-    "time"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sync"
+	"time"
 )
 
 // Logger is a minimal structured logger.
 type Logger struct {
-    mu  sync.Mutex
-    out *log.Logger
+	mu     sync.Mutex
+	out    *log.Logger
+	writer io.Writer
 }
 
 // New creates a default logger writing to stdout.
 func New() *Logger {
-    return &Logger{out: log.New(os.Stdout, "", 0)}
+	return &Logger{out: log.New(os.Stdout, "", 0), writer: os.Stdout}
 }
 
 // Infof prints informational message.
 func (l *Logger) Infof(format string, args ...any) {
-    if l == nil || l.out == nil {
-        return
-    }
-    l.mu.Lock()
-    l.out.Printf(prefix("INFO")+format, args...)
-    l.mu.Unlock()
+	if l == nil || l.out == nil {
+		return
+	}
+	l.mu.Lock()
+	l.out.Printf(prefix("INFO")+format, args...)
+	l.mu.Unlock()
 }
 
 // Errorf prints error message.
 func (l *Logger) Errorf(format string, args ...any) {
-    if l == nil || l.out == nil {
-        return
-    }
-    l.mu.Lock()
-    l.out.Printf(prefix("ERROR")+format, args...)
-    l.mu.Unlock()
+	if l == nil || l.out == nil {
+		return
+	}
+	l.mu.Lock()
+	l.out.Printf(prefix("ERROR")+format, args...)
+	l.mu.Unlock()
 }
 
 func prefix(level string) string {
-    return fmt.Sprintf("%s [%s] ", time.Now().UTC().Format(time.RFC3339), level)
+	return fmt.Sprintf("%s [%s] ", time.Now().UTC().Format(time.RFC3339), level)
 }
 
-// WithPrefix returns a shallow copy that prints with static prefix.
+// WithPrefix returns a logger that prints with static prefix.
 func (l *Logger) WithPrefix(pfx string) *Logger {
-    if l == nil {
-        return nil
-    }
-    copy := *l
-    copy.out = log.New(os.Stdout, pfx+" ", 0)
-    return &copy
+	if l == nil {
+		return nil
+	}
+	writer := l.writer
+	if writer == nil {
+		writer = os.Stdout
+	}
+	return &Logger{out: log.New(writer, pfx+" ", 0), writer: writer}
 }
 
 /*
@@ -111,5 +115,3 @@ Filler for ≥100 lines.
 90
 100
 */
-
-


### PR DESCRIPTION
### Motivation
- Prevent copying a `sync.Mutex` by avoiding struct copies when creating a prefixed logger. 
- Preserve the configured output destination so prefixed loggers write to the same `io.Writer` as the original logger. 

### Description
- Add a `writer io.Writer` field to `Logger` to track the destination explicitly. 
- Initialize `writer` in `New` as `os.Stdout` and return `&Logger{out: ..., writer: ...}`. 
- Rework `WithPrefix` to always construct and return a fresh `Logger` (`return &Logger{...}`) that uses the stored `writer` instead of doing `copy := *l`, ensuring the mutex is not inherited. 
- Update the `WithPrefix` comment to remove the phrase about a "shallow copy" and import `io` for the new field. 

### Testing
- Ran `go test ./...` and it completed successfully for all packages. 
- Ran `git diff --check` and there were no trailing whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a207bf5272083329853a0a04c0db7f9)